### PR TITLE
Simplify the registration check

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -11,10 +11,10 @@ const backoffOptions = {
 
 function jsonToXml(config) {
   let xml = '';
-  
+
   for (const [key, value] of Object.entries(config)) {
     // Skip null, undefined values and empty strings
-    if (value === undefined || value === null || value === '') continue;    
+    if (value === undefined || value === null || value === '') continue;
 
     if (typeof value === 'boolean') {
       xml += `<key>${key}</key>\n<${value} />\n`;
@@ -24,7 +24,7 @@ function jsonToXml(config) {
       xml += `<key>${key}</key>\n<string>${value}</string>\n`;
     }
   }
-  
+
   return xml;
 }
 
@@ -77,7 +77,7 @@ async function writeLinuxConfiguration(
     auth_client_secret,
     unique_client_id
   };
-  
+
   const xmlContent = jsonToXml(configObj);
   const config = `
   <dict>
@@ -105,7 +105,7 @@ async function writeMacOSConfiguration(
     service_mode: "warp",
     auto_connect: 1
   };
-  
+
   const xmlContent = jsonToXml(configObj);
   const config = `
   <?xml version="1.0" encoding="UTF-8"?>
@@ -144,7 +144,7 @@ async function writeWindowsConfiguration(
     ${xmlContent}
   </dict>
   `;
-  
+
   if (!fs.existsSync("C:\\ProgramData\\Cloudflare")) {
     fs.mkdirSync("C:\\ProgramData\\Cloudflare");
   }
@@ -177,9 +177,9 @@ async function checkWARPRegistration(organization, is_registered) {
     },
   };
 
-  await exec.exec("warp-cli", ["--accept-tos", "settings"], options);
+  await exec.exec("warp-cli", ["--accept-tos", "registration", "organization"], options);
 
-  const registered = output.includes(`Organization: ${organization}`);
+  const registered = output.includes(`${organization}`);
   if (is_registered && !registered) {
     throw new Error("WARP is not registered");
   } else if (!is_registered && registered) {
@@ -224,8 +224,8 @@ export async function run() {
   const auth_client_secret = core.getInput("auth_client_secret", {
     required: true,
   });
-  const unique_client_id = core.getInput("unique_client_id", { 
-    required: false 
+  const unique_client_id = core.getInput("unique_client_id", {
+    required: false
   });
   const configure_docker_dns = core.getBooleanInput("configure_docker_dns", {
     required: false,


### PR DESCRIPTION
Use `warp-cli resitration organisation command to check registration => This is more explicit than parsing the all settings. The side effect is that it also produced a much cleaner output.