### PR TITLE
Adjust backoff options to reduce error rate

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -5,8 +5,10 @@ import * as tc from "@actions/tool-cache";
 import { backOff } from "exponential-backoff";
 
 const backoffOptions = {
-  numOfAttempts: 10,
-  maxDelay: 4000,
+  delayFirstAttempt: true,
+  startingDelay: 2000,
+  numOfAttempts: 15,
+  maxDelay: 5000,
 };
 
 function jsonToXml(config) {


### PR DESCRIPTION
We ended up having a lot of error like this:
![image](https://github.com/user-attachments/assets/30ebaf50-1888-4437-a256-1de820ae8238)

In order to reduc the error rate, this PR introduce several change in the exponential backoff options:
- a starting delay of 2s
- an increase of the retry attempt
- an increase of the max delay